### PR TITLE
fix duplicated topics in article_index page

### DIFF
--- a/backend/src/topics/services.rs
+++ b/backend/src/topics/services.rs
@@ -259,6 +259,7 @@ pub async fn topics_by_user_id(
     }
 
     let mut topic_ids = topic_ids_dup.clone();
+    topic_ids.sort();
     topic_ids.dedup();
 
     let mut topics: Vec<Topic> = vec![];


### PR DESCRIPTION
修复文章详情页出现重复topic，因为数组的dedup方法只去除相邻的重复项，所以要先sort，顺带使文章内topics从多到少排序。